### PR TITLE
修复（Nuxt）：更新 TypeScript 配置文件

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,8 +36,8 @@ export default defineNuxtConfig({
     vueI18n: './i18n.config.ts',
     baseUrl: 'https://fastsend.ing',
     locales: [
-      { code: 'en', iso: 'en-US' },
-      { code: 'zh', iso: 'zh-CN' }
+      { code: 'en', language: 'en-US' },
+      { code: 'zh', language: 'zh-CN' }
     ],
     defaultLocale: 'en',
     detectBrowserLanguage: {


### PR DESCRIPTION
### 改了什么？

修改 `nuxt.config.ts` ，按照 i18n 插件文档说明使用移除已弃用的设置项，并切换到新的配置项。

### 更多信息

- 参见 [安装 · i18n · Nuxt 模块 · Nuxt 框架](https://nuxtjs.org.cn/modules/i18n#install)