### PR TITLE
[New Feature]: Automatically detect file extension (#19)

### DIFF
--- a/app/stores/recipientTransfer.ts
+++ b/app/stores/recipientTransfer.ts
@@ -1,5 +1,4 @@
 import CryptoJS from 'crypto-js'
-import { PeerDataChannel } from '~/utils/PeerDataChannel'
 import {
   createRecipientCurrentFileState,
   createRecipientStatusState,
@@ -10,6 +9,7 @@ import {
   type SyncDirState,
   type UserInfo
 } from '~/types/transfer'
+import { PeerDataChannel } from '~/utils/PeerDataChannel'
 
 /**
  * 接收端业务仓库。
@@ -415,9 +415,14 @@ export const useRecipientTransferStore = defineStore('recipientTransfer', () => 
     try {
       if (peerFilesInfo.value.type === 'transFile') {
         if (isModernFileAPISupport.value) {
+          const ext = curFile.value.name.match(/(\.\w+)$/)?.[1]
+          const safeName = ext
+            ? curFile.value.name.slice(0, -ext.length).replace(/\./g, '_') + ext
+            : curFile.value.name
           saveFileFH = await window.showSaveFilePicker({
             startIn: 'downloads',
-            suggestedName: curFile.value.name
+            suggestedName: safeName,
+            ...(ext && { types: [{ description: '', accept: { 'application/x-fastsend': [ext] } }] })
           })
           curFileWriter = await saveFileFH?.createWritable()
         }


### PR DESCRIPTION
此 PR 修改了 `window.showSaveFilePicker()` 方法的调用逻辑：

1. 从发送方传递的单个文件名中识别文件扩展名后缀，在接收方对文件进行「另存为」时锁定文件的扩展名，避免用户重命名文件过程中错误移除或修改扩展名；
2. 对于发送方传输无扩展名文件，回退至原有行为，由用户自由指定文件名（及扩展名部分）。

- Resolve #19 

> [!IMPORTANT]
> 
> 「仅选中文件名部分」无法实现，仅能实现在接收方删除原有的扩展名后，借助文件类型选择器为接收方自动补充追加扩展名。