### PR TITLE
[New Feature]: Initialize Amazon Q Developer Memory Bank

### DIFF
--- a/.amazonq/rules/memory-bank/guidelines.md
+++ b/.amazonq/rules/memory-bank/guidelines.md
@@ -1,0 +1,154 @@
+# FastSend - Development Guidelines
+
+## Code Formatting
+
+- Prettier config: `semi:false`, `singleQuote:true`, `printWidth:100`, `trailingComma:"none"`, `tabWidth:2`
+- No semicolons; single quotes for strings; trailing commas omitted everywhere
+- Max line width 100 characters
+
+## TypeScript Conventions
+
+- Strict TypeScript throughout; avoid `any` except at explicit integration boundaries (WebRTC peer objects, legacy file API)
+- Use `@ts-ignore` only with an inline comment explaining why (e.g., incomplete browser type definitions)
+- Prefer explicit return types on public class methods; omit on simple arrow functions
+- Use `type` for union/alias types, `interface` for object shapes
+- Factory functions (e.g., `createSenderStatusState()`) are co-located with their types in `app/types/transfer.ts`
+
+## Vue / Nuxt Patterns
+
+- All pages use `<script setup lang="ts">` (Composition API)
+- Auto-imports are enabled for composables, stores, and Nuxt utilities — do not manually import `ref`, `computed`, `defineStore`, `useI18n`, `useRouter`, etc.
+- Stores are imported via auto-import by their exported function name (e.g., `useAppStore()`)
+- Use `import.meta.client` to guard browser-only code in SSR context; check `typeof window === 'undefined'` in utilities
+- `useLocalePath` + `router.replace(localePath('/'))` for programmatic navigation with i18n
+
+## Pinia Store Pattern (Setup Store)
+
+All stores use the **setup store** style — `defineStore('name', () => { ... })`:
+
+```ts
+export const useMyStore = defineStore('myStore', () => {
+  // reactive state
+  const value = ref<MyType>(createMyType())
+
+  // private mutable variables (not reactive, not returned)
+  let ws: WebSocket | null = null
+
+  // always provide resetState() and dispose()
+  function resetState() { dispose(); value.value = createMyType() }
+  function dispose() { ws?.close(); ws = null }
+
+  // expose only what pages need
+  return { value, resetState, dispose }
+})
+```
+
+- `resetState()` calls `dispose()` then resets all `ref` values using factory functions
+- `dispose()` clears intervals, closes WebSocket, calls `pdc?.dispose()`, nulls all mutable refs
+- Pages call `initialize()` in `onMounted` and `cleanup()` (which calls `dispose()`) in `onUnmounted`
+- Only expose state and actions that pages actually need in the `return` object
+
+## WebRTC / PeerDataChannel Usage
+
+```ts
+// Sender creates PDC without initializeDataChannel
+pdc = new PeerDataChannel({ iceServers: pubIceServers })
+
+// Recipient creates PDC with initializeDataChannel: true
+pdc = new PeerDataChannel({ iceServers: pubIceServers, initializeDataChannel: true })
+
+// Wire up callbacks before any SDP exchange
+pdc.onSDP = (sdp) => ws?.send(JSON.stringify({ type: 'sdp', data: sdp }))
+pdc.onICECandidate = (candidate) => ws?.send(JSON.stringify({ type: 'candidate', data: candidate }))
+pdc.onConnected = () => { /* update status */ }
+pdc.onDispose = () => { /* handle disconnect */ }
+pdc.onReceive = async (data) => { /* handle string or ArrayBuffer */ }
+
+// Send data (must be called serially — await each call)
+await pdc.sendData(JSON.stringify({ type: 'user', data: userInfo }))
+await pdc.sendData(arrayBuffer)
+```
+
+- Always use `pubIceServers` from `~/utils/publicStunList` for ICE configuration
+- `sendData` must be called serially (one at a time); it is not safe to call concurrently
+- Always call `pdc.dispose()` in the store's `dispose()` function
+
+## Signaling Protocol (WebSocket Messages)
+
+JSON messages over WebSocket to `/api/connect`:
+
+| Direction     | Message                         | Meaning                              |
+| ------------- | ------------------------------- | ------------------------------------ |
+| Client→Server | `{type:"send"}`                 | Register as sender, get 4-digit code |
+| Client→Server | `{type:"receive", code:"XXXX"}` | Register as recipient                |
+| Server→Client | `{type:"code", code:"XXXX"}`    | Sender's pairing code                |
+| Server→Client | `{type:"status", code:0}`       | Pairing successful                   |
+| Server→Client | `{type:"status", code:404}`     | Code not found                       |
+| Relayed       | `{type:"sdp", data:...}`        | SDP offer/answer                     |
+| Relayed       | `{type:"candidate", data:...}`  | ICE candidate                        |
+
+## P2P Data Protocol (over RTCDataChannel)
+
+Messages sent via `pdc.sendData()`:
+
+| Direction        | Message                             | Meaning                |
+| ---------------- | ----------------------------------- | ---------------------- |
+| Sender→Recipient | `{type:"user", data:UserInfo}`      | User info exchange     |
+| Sender→Recipient | `{type:"files", data:FilesPayload}` | File manifest          |
+| Sender→Recipient | `{type:"fileDone", data:md5Base64}` | File complete + hash   |
+| Recipient→Sender | `{type:"reqFile", data:key}`        | Request a file by key  |
+| Recipient→Sender | `{type:"calcFileHash", data:key}`   | Request MD5 of a file  |
+| Sender→Recipient | `{type:"fileHash", data:md5Base64}` | MD5 response           |
+| Either           | `{type:"err", data:code}`           | Error code             |
+| Recipient→Sender | `{type:"done"}`                     | All transfers complete |
+
+## File Map (FlatFileMap) Convention
+
+Keys are slash-separated relative paths (e.g., `"folder/sub/file.txt"`).
+Values are `FlatFileItem`: `{ paths: string[], size: number, lastModified: number, file?: File }`.
+
+```ts
+// Build from directory handle
+const fileMap = await dealFilesFromHandler(dirHandle)
+
+// Build from file list (webkitdirectory input)
+const fileMap = await dealFilesFormList(fileList)
+
+// Build from single file
+const fileMap = dealFilesFormFile(file)
+```
+
+## Error Handling Patterns
+
+- Errors are stored in `status.value.error` (blocking) or `status.value.warn` (non-blocking) as `MessageState { code, msg }`
+- Code `0` means no error; non-zero codes are shown in the UI
+- Always show user feedback via `toast.add({ severity, summary, detail, life: 5e3 })`
+- `console.error` for unexpected errors; `console.warn` for expected/recoverable situations
+- Swallow ICE candidate errors silently (they are expected in some network environments)
+
+## SSR Safety
+
+- Guard all browser API access: `typeof window === 'undefined'`, `import.meta.client`
+- File System Access API (`showDirectoryPicker`, `showSaveFilePicker`) requires HTTPS and is only available client-side
+- `localStorage` access must be wrapped in SSR checks
+
+## Styling
+
+- Use Tailwind utility classes for layout and spacing
+- PrimeVue components are **unstyled** — styled via the Aura preset in `presets/aura/`
+- Dark mode uses the `class` strategy (`dark` class on `<html>`); managed by `@nuxtjs/color-mode`
+- Custom color tokens (`primary-*`, `surface-*`) are CSS variables bridged into Tailwind via `tailwind.config.js`
+
+## i18n
+
+- All user-visible strings must have entries in both `en` and `zh` in `i18n/i18n.config.ts`
+- Use `const { t } = useI18n()` in stores and components; reference keys like `t('hint.transCompleted')`
+- Navigation uses `useLocalePath()` to prefix routes with locale
+
+## Server-Side Conventions
+
+- WebSocket handler uses `defineWebSocketHandler` (Nitro H3)
+- Three TTLCache pools manage connection lifecycle: `initPool` → `waitConnectPool` → `initedPool`
+- All peer objects are plain objects with duck-typed properties (`peer.id`, `peer.pairPeer`, `peer.isInited`)
+- `increaseTransCount()` is called exactly once per successful pairing in `initReceive()`
+- The `transCount` file is persisted to disk on every increment (simple file-based persistence)

--- a/.amazonq/rules/memory-bank/product.md
+++ b/.amazonq/rules/memory-bank/product.md
@@ -1,0 +1,36 @@
+# FastSend - Product Overview
+
+## Purpose
+
+FastSend is a browser-based peer-to-peer file transfer tool built on WebRTC. It enables direct, encrypted file sharing between browsers without uploading files to a server. The signaling server only facilitates connection establishment; actual data flows directly between peers.
+
+## Value Proposition
+
+- Zero file storage on server — files never leave the sender's browser until received by the peer
+- Works across LAN and WAN; LAN connections are automatically optimized for speed
+- No account or installation required — accessible via browser at fastsend.ing
+- Installable as a PWA for lightweight offline-capable access
+
+## Key Features
+
+- **File transfer**: Send individual files peer-to-peer
+- **Directory transfer**: Send entire folder structures preserving hierarchy
+- **Directory sync**: Diff two directories and transfer only added/updated/deleted files
+- **End-to-end encryption**: WebRTC DTLS encryption on all data channels
+- **QR code sharing**: Share connection codes via QR for mobile pairing
+- **Bilingual UI**: Full Chinese and English interface (i18n)
+- **Dark/light mode**: System-preference-aware color scheme
+- **PWA support**: Installable, with service worker caching
+
+## Target Users
+
+- Developers and power users transferring files between devices on LAN
+- Users needing quick cross-device file sharing without cloud storage
+- Teams doing directory synchronization without a dedicated sync tool
+
+## Use Cases
+
+1. Send a large file from desktop to laptop on the same network
+2. Sync a project directory from one machine to another
+3. Share files with a mobile device by scanning a QR code
+4. Transfer files across the internet when no shared cloud storage is available

--- a/.amazonq/rules/memory-bank/structure.md
+++ b/.amazonq/rules/memory-bank/structure.md
@@ -1,0 +1,80 @@
+# FastSend - Project Structure
+
+## Directory Layout
+
+```
+FastSend/
+├── app/                        # Nuxt 4 frontend application (srcDir)
+│   ├── assets/main.css         # Global Tailwind CSS entry
+│   ├── components/             # Shared Vue components
+│   ├── composables/            # Vue composables (useXxx pattern)
+│   ├── pages/                  # Route pages: index, sender, recipient
+│   ├── stores/                 # Pinia stores (one per domain)
+│   ├── types/                  # TypeScript types and factory functions
+│   ├── utils/                  # Pure utilities and WebRTC core
+│   ├── app.config.ts           # Nuxt app config (currently empty)
+│   └── app.vue                 # Root Vue component
+├── server/                     # Nitro server (signaling + API)
+│   ├── api/
+│   │   ├── connect.ts          # WebSocket signaling handler
+│   │   ├── getIP.post.ts       # Client IP lookup endpoint
+│   │   └── transCount.post.ts  # Transfer counter endpoint
+│   └── utils/TransCount.ts     # Persistent transfer counter (file-based)
+├── public/                     # Static assets + PWA service worker
+│   └── sw.js                   # Custom injectManifest service worker
+├── presets/aura/               # PrimeVue unstyled theme preset (Aura)
+├── i18n/i18n.config.ts         # i18n messages (en + zh)
+├── nuxt.config.ts              # Nuxt configuration
+├── tailwind.config.js          # Tailwind configuration
+└── Dockerfile / docker-compose.yaml
+```
+
+## Core Components
+
+### Pages
+
+- `index.vue` — Home: file/folder picker, transfer mode selection
+- `sender.vue` — Sender flow: QR code, connection status, transfer progress
+- `recipient.vue` — Recipient flow: code entry, file acceptance, download
+
+### Stores (Pinia, Setup Store style)
+
+- `app.ts` — Global UI state (full-screen loader)
+- `user.ts` — User nickname/avatar, confirm-default preference
+- `transferConfig.ts` — Selected files/folders, transfer type, file map building
+- `senderTransfer.ts` — Full sender WebSocket + WebRTC lifecycle and file sending
+- `recipientTransfer.ts` — Full recipient WebSocket + WebRTC lifecycle and file receiving
+- `home.ts` — Home page UI state
+
+### Utils
+
+- `PeerDataChannel.ts` — WebRTC RTCPeerConnection + RTCDataChannel wrapper with chunked send/receive and an EventQueue for serial async processing
+- `files.ts` — File system helpers (directory reading, flat map building, diff)
+- `index.ts` — Shared utilities (formatBytes, formatTime, copyToClipboard, etc.)
+- `publicStunList.ts` — Public STUN/TURN server list (`pubIceServers`)
+
+### Server
+
+- `connect.ts` — WebSocket signaling: manages three TTLCache pools (init, waitConnect, inited), pairs sender/receiver, relays SDP and ICE candidates
+- `TransCount.ts` — Simple file-persisted counter incremented on each successful pairing
+
+## Architectural Patterns
+
+### Signaling Flow
+
+1. Sender opens WebSocket → sends `{type:"send"}` → server returns 4-digit code
+2. Recipient opens WebSocket → sends `{type:"receive", code:"XXXX"}` → server pairs them
+3. All subsequent messages (SDP offer/answer, ICE candidates) are relayed transparently by the server
+4. Once WebRTC connects, the WebSocket is no longer needed for data
+
+### Data Transfer Protocol
+
+- `PeerDataChannel.sendData` prepends a JSON header `{count, type}` then sends data in 32 KB blocks
+- Receiver reassembles chunks via `EventQueue` (serial promise chain) before calling `onReceive`
+- File integrity verified with MD5 hash sent after each file
+
+### State Management
+
+- Each page has a dedicated store that owns the full connection lifecycle
+- Stores expose `initialize()` and `cleanup()` called from page `onMounted`/`onUnmounted`
+- Reactive state (`ref`) drives UI; computed properties derive display values

--- a/.amazonq/rules/memory-bank/tech.md
+++ b/.amazonq/rules/memory-bank/tech.md
@@ -1,0 +1,73 @@
+# FastSend - Technology Stack
+
+## Runtime & Language
+
+- **Node.js** — server runtime (Nitro/H3)
+- **TypeScript** — used throughout (`app/`, `server/`, config files)
+- **Vue 3** (^3.5.31) — Composition API with `<script setup>`
+- **Nuxt 4** (^4.4.2) — full-stack framework; `srcDir: 'app'`
+
+## Frontend
+
+| Technology         | Version | Role                                          |
+| ------------------ | ------- | --------------------------------------------- |
+| Vue 3              | ^3.5.31 | UI framework                                  |
+| Pinia              | ^3.0.4  | State management                              |
+| PrimeVue           | ^4.5.4  | UI component library (unstyled + Aura preset) |
+| Tailwind CSS       | ^3.4.17 | Utility-first styling                         |
+| @nuxtjs/i18n       | ^10.2.4 | Bilingual (en/zh)                             |
+| @nuxtjs/color-mode | ^4.0.0  | Dark/light mode                               |
+| @vite-pwa/nuxt     | ^1.1.1  | PWA + service worker                          |
+| @nuxtjs/seo        | ^5.1.0  | SEO meta tags                                 |
+| webrtc-adapter     | ^9.0.4  | WebRTC cross-browser shim                     |
+| qrcode             | ^1.5.4  | QR code generation                            |
+| crypto-js          | ^4.2.0  | MD5 file integrity hashing                    |
+
+## Server (Nitro)
+
+| Technology                              | Role                                            |
+| --------------------------------------- | ----------------------------------------------- |
+| Nitro (built into Nuxt 4)               | Server engine with experimental WebSocket       |
+| H3 WebSocket (`defineWebSocketHandler`) | Signaling server                                |
+| @isaacs/ttlcache                        | TTL-based connection pools                      |
+| Node.js `fs`                            | Persistent transfer counter (`transCount` file) |
+
+## Build & Tooling
+
+- **Package manager**: Yarn 1.22.22 (classic)
+- **Formatter**: Prettier 3.x — `semi:false`, `singleQuote:true`, `printWidth:100`, `trailingComma:"none"`, `tabWidth:2`
+- **TypeScript**: strict mode via `tsconfig.json`
+- **Docker**: multi-stage `Dockerfile` + `docker-compose.yaml`
+
+## Development Commands
+
+```bash
+yarn install          # Install dependencies
+yarn dev              # Dev server (--host, accessible on LAN)
+yarn build            # Production build → .output/
+yarn generate         # Static generation
+yarn preview          # Preview production build
+node .output/server/index.mjs  # Run production server
+```
+
+## Docker
+
+```bash
+docker build -t fastsend .
+docker run -d --name fastsend -p 3000:3000 fastsend
+docker-compose up -d
+```
+
+## Key Configuration
+
+- `nuxt.config.ts` — `srcDir:'app'`, Nitro experimental WebSocket, PrimeVue unstyled with Aura preset, PWA injectManifest strategy
+- `tailwind.config.js` — dark mode via `class`, custom `primary-*` and `surface-*` CSS variable colors bridging PrimeVue tokens
+- `i18n/i18n.config.ts` — inline messages for `en` and `zh` locales
+- `.prettierrc.json` — project-wide formatting rules
+
+## Browser APIs Used
+
+- `RTCPeerConnection` / `RTCDataChannel` — WebRTC P2P
+- `showDirectoryPicker` / `showSaveFilePicker` — File System Access API (HTTPS only)
+- `BeforeInstallPromptEvent` — PWA install prompt
+- Service Worker (`public/sw.js`) — PWA caching with injectManifest


### PR DESCRIPTION
## 变更概述

为 VSCode Amazon Q 插件初始化项目级 Memory Bank，位于 .amazonq/rules/memory-bank/ 目录下。

## 变更内容

新增以下四个文档文件，为 Amazon Q AI 助手提供必要的项目上下文与架构知识：

- **`guidelines.md`** — 开发规范：代码格式、TypeScript 约定、Vue/Nuxt 模式、Pinia Store 风格、WebRTC 用法、信令协议、P2P 数据协议、错误处理、SSR 安全及样式规范
- **`product.md`** — 产品概述：项目目的、核心价值主张、主要功能特性与典型使用场景
- **`structure.md`** — 项目结构：目录布局、核心组件说明、架构模式与数据流
- **`tech.md`** — 技术栈：运行时、前端依赖、服务端依赖、构建工具及关键配置说明

## 变更目的

通过 Memory Bank 机制，使 Amazon Q 在每次对话中自动获取项目背景，从而提供更准确、更符合项目规范的代码建议与辅助。