### PR TITLE
Fixed an issue where Docker images could not be built

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Nuxt dev/build outputs
+.output
+.data
+.nuxt
+.nitro
+.cache
+dist
+
+# Node dependencies
+node_modules
+
+# Logs
+logs
+*.log
+
+# Misc
+.DS_Store
+.fleet
+.idea
+
+# Local env files
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:24-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json yarn.lock ./
+COPY package.json yarn.lock .yarnrc.yml ./
 RUN corepack enable && yarn install --frozen-lockfile
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:24-alpine AS builder
 WORKDIR /app
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+RUN corepack enable && yarn install --frozen-lockfile
 
 COPY . .
 RUN yarn build


### PR DESCRIPTION
I modified the Dockerfile because the Docker image build was failing for the following reasons
- Since the default version of Yarn is too old, we'll use the version specified in `package.json` by running `corepack enable`.
- The .yarnrc.yml file had not been copied to the build environment, causing the module to fail to link.